### PR TITLE
Add xz-utils to preinstalled debian packages

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -128,6 +128,7 @@ RUN version=$( \
         libxtst6 \
         lsb-release \
         wget \
+        xz-utils \
     && \
     apt-get -o Acquire::Check-Valid-Until=false -y --force-yes autoremove && \
     apt-get -o Acquire::Check-Valid-Until=false -y --force-yes autoclean && \

--- a/docker/wheezy/Dockerfile
+++ b/docker/wheezy/Dockerfile
@@ -49,6 +49,7 @@ RUN mv /etc/apt/sources.list /etc/apt/sources.list.bak && \
         libxtst6 \
         lsb-release \
         wget \
+        xz-utils \
     && \
     apt-get -o Acquire::Check-Valid-Until=false -y --force-yes autoremove && \
     apt-get -o Acquire::Check-Valid-Until=false -y --force-yes autoclean && \


### PR DESCRIPTION
Fixes #26 

This adds `xz-utils`, which will be required for unpacking firefox packages as of https://blog.nightly.mozilla.org/2024/11/28/announcing-faster-lighter-firefox-downloads-for-linux-with-tar-xz-packaging/